### PR TITLE
Fix/issue 2

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -5,3 +5,4 @@ Thumbs.db
 *.swo
 .vscode/
 output*.pptx
+__pycache__/

--- a/README.md
+++ b/README.md
@@ -38,7 +38,6 @@ python -m http.server 8000
 ├── libs/                 # 图片资源（logo 等）
 ├── export_to_pptx.py     # PPTX 导出脚本
 ├── requirements.txt      # Python 依赖
-├── 演示.mp4              # 效果演示视频
 └── README.md
 ```
 

--- a/README.md
+++ b/README.md
@@ -122,10 +122,29 @@ python -m http.server 8000
 
 三种风格：`block-normal`（绿）、`block-alert`（红）、`block-example`（深绿）。
 
+### 图片
+
+```html
+<figure>
+  <img src="libs/example.png" alt="示例图片">
+  <figcaption>图注文字</figcaption>
+</figure>
+```
+
+`<figcaption>` 作为图注，`.source` 可标注来源。
+
 ### 数学公式
+
+块级公式：
 
 ```html
 <div class="math math-display">E = mc^2</div>
+```
+
+行内公式：
+
+```html
+<p>质能方程 <span class="math">E = mc^2</span> 由爱因斯坦提出。</p>
 ```
 
 使用 KaTeX 渲染，支持标准 LaTeX 语法。

--- a/css/sysu-theme.css
+++ b/css/sysu-theme.css
@@ -40,7 +40,10 @@ body {
 #slide-deck {
   width: 1280px;
   height: 720px;
-  background: var(--sysu-white);
+  background-color: var(--sysu-white);
+  background-repeat: no-repeat;
+  background-position: left 20px bottom 36px;
+  background-size: auto 110px;
   position: relative;
   overflow: hidden;
   text-align: left;
@@ -127,7 +130,7 @@ li::marker {
 }
 
 .slide-title-page .title-logo {
-  height: 80px;
+  height: 240px;
   margin-bottom: 30px;
 }
 
@@ -535,18 +538,7 @@ pre code {
    Watermark
    ═══════════════════════════════════════════════════════════════ */
 
-.sysu-watermark {
-  position: absolute;
-  bottom: 36px;
-  left: 20px;
-  z-index: -1;
-  opacity: 0.8;
-  pointer-events: none;
-}
 
-.sysu-watermark img {
-  height: 110px;
-}
 
 /* ═══════════════════════════════════════════════════════════════
    Footnote

--- a/css/sysu-theme.css
+++ b/css/sysu-theme.css
@@ -471,7 +471,7 @@ pre code {
   top: 0;
   left: 0;
   width: 100%;
-  height: 45px;
+  height: 50px;
   background: var(--sysu-black);
   z-index: 101;
   display: flex;

--- a/css/sysu-theme.css
+++ b/css/sysu-theme.css
@@ -69,6 +69,26 @@ body {
   display: flex;
 }
 
+.slide > * {
+  min-height: 0;
+  flex-shrink: 1;
+}
+
+.slide figure {
+  flex: 1;
+  min-height: 0;
+  display: flex;
+  flex-direction: column;
+  align-items: center;
+  justify-content: center;
+  padding-bottom: 20px;
+}
+
+.slide figure img {
+  max-height: 100%;
+  object-fit: contain;
+}
+
 /* ═══════════════════════════════════════════════════════════════
    Typography
    ═══════════════════════════════════════════════════════════════ */

--- a/css/sysu-theme.css
+++ b/css/sysu-theme.css
@@ -212,6 +212,10 @@ li::marker {
    Section Divider (章节页)
    ═══════════════════════════════════════════════════════════════ */
 
+.slide.no-header.no-footer {
+  padding: 60px;
+}
+
 .slide-section-divider {
   display: flex;
   flex-direction: column;
@@ -220,7 +224,7 @@ li::marker {
   text-align: center;
   width: calc(100% + 120px);
   height: 50%;
-  margin-top: 10%;
+  margin-top: auto;
   margin-bottom: auto;
   margin-left: -60px;
   background: var(--sysu-green);

--- a/export_to_pptx.py
+++ b/export_to_pptx.py
@@ -102,28 +102,6 @@ def capture_slides(html_path: str, output_dir: str):
                 page.keyboard.press("ArrowRight")
                 page.wait_for_timeout(500)
 
-            page.evaluate(
-                "() => {"
-                "  const old = document.querySelector('.slide .watermark-clone');"
-                "  if (old) old.remove();"
-                "  const wm = document.querySelector('.sysu-watermark');"
-                "  if (!wm) return;"
-                "  const visible = document.querySelector('#slide-deck .slide[style*=\"flex\"]');"
-                "  if (!visible) return;"
-                "  visible.style.position = 'relative';"
-                "  visible.style.zIndex = '0';"
-                "  const clone = wm.cloneNode(true);"
-                "  clone.classList.add('watermark-clone');"
-                "  clone.style.position = 'absolute';"
-                "  clone.style.bottom = '36px';"
-                "  clone.style.left = '20px';"
-                "  clone.style.zIndex = '-1';"
-                "  clone.style.opacity = '0.8';"
-                "  clone.style.pointerEvents = 'none';"
-                "  visible.appendChild(clone);"
-                "}"
-            )
-
             deck = page.locator("#slide-deck")
 
             filename = os.path.join(output_dir, f"slide_{i:03d}.png")

--- a/export_to_pptx.py
+++ b/export_to_pptx.py
@@ -11,6 +11,9 @@ import os
 import sys
 import tempfile
 import shutil
+import threading
+import http.server
+import socketserver
 from pathlib import Path
 
 from playwright.sync_api import sync_playwright
@@ -22,17 +25,50 @@ SLIDE_WIDTH = 1280
 SLIDE_HEIGHT = 720
 
 
+def _find_free_port():
+    with socketserver.TCPServer(("", 0), None) as s:
+        return s.server_address[1]
+
+
+def _start_server(directory: str, port: int):
+    handler = http.server.SimpleHTTPRequestHandler
+    os.chdir(directory)
+    server = socketserver.TCPServer(("", port), handler)
+    server.serve_forever()
+
+
 def capture_slides(html_path: str, output_dir: str):
     html_path = os.path.abspath(html_path)
     if not os.path.isfile(html_path):
         print(f"错误：找不到文件 {html_path}")
         sys.exit(1)
 
-    file_url = Path(html_path).as_uri()
+    html_dir = os.path.dirname(html_path)
+    html_file = os.path.basename(html_path)
+
+    port = _find_free_port()
+    server_thread = threading.Thread(
+        target=_start_server, args=(html_dir, port), daemon=True
+    )
+    server_thread.start()
+
+    file_url = f"http://localhost:{port}/{html_file}"
+    print(f"本地 HTTP 服务器已启动: {file_url}")
+
     screenshots = []
 
     with sync_playwright() as p:
-        browser = p.chromium.launch(channel="msedge")
+        browser = None
+        for ch in ("msedge", "chrome"):
+            try:
+                browser = p.chromium.launch(channel=ch)
+                print(f"使用系统 {ch}")
+                break
+            except Exception:
+                continue
+        if browser is None:
+            browser = p.chromium.launch()
+            print("使用 Playwright 内置 Chromium")
         page = browser.new_page(
             viewport={"width": SLIDE_WIDTH, "height": SLIDE_HEIGHT},
             device_scale_factor=2,

--- a/js/sysu-slide.js
+++ b/js/sysu-slide.js
@@ -93,10 +93,7 @@
     deck.appendChild(progress);
 
     if (config.watermark) {
-      const wm = document.createElement('div');
-      wm.className = 'sysu-watermark';
-      wm.innerHTML = '<img src="' + config.logo + '" alt="logo">';
-      deck.appendChild(wm);
+      deck.style.backgroundImage = 'url("' + config.logo + '")';
     }
   }
 
@@ -162,10 +159,12 @@
   }
 
   function updateWatermark() {
-    var wm = document.querySelector('.sysu-watermark');
-    if (!wm) return;
+    var deck = document.getElementById('slide-deck');
+    if (!deck || !config.watermark) return;
     var slide = slides[currentSlide];
-    wm.style.display = slide && slide.classList.contains('no-watermark') ? 'none' : '';
+    deck.style.backgroundImage = slide && slide.classList.contains('no-watermark')
+      ? 'none'
+      : 'url("' + config.logo + '")';
   }
 
   function highlightTOC() {

--- a/sections/00-title.html
+++ b/sections/00-title.html
@@ -1,6 +1,6 @@
 <div class="slide no-header no-footer no-watermark">
   <div class="slide-title-page">
-    <img class="title-logo" src="libs/sysu_logo.png" alt="SYSU Logo">
+    <img class="title-logo" src="libs/sysu_big_logo.jpeg" alt="SYSU Logo">
     <h1>中山大学PPT模板</h1>
     <div class="subtitle">使用 HTML/CSS/JS 制作演示文稿</div>
     <div class="author-info">


### PR DESCRIPTION
Fixes #2 

做了以下修改：
- 修复 slide 内容超高时被截断的问题（flex 收缩 + figure 自适应缩放）
- 修复标题页/章节页上下留白不对称、视觉不居中的问题
- 修复 header(50px) 与 progress(45px) 高度差 5px 导致的切换抖动
- README 补充图片插入、行内公式的说明
- 移除 演示.mp4，改用 GitHub issue 链接查看效果